### PR TITLE
check if hit misses in raycast

### DIFF
--- a/client/cl_planting.lua
+++ b/client/cl_planting.lua
@@ -31,6 +31,7 @@ RegisterNetEvent('weedplanting:client:UseWeedSeed', function()
     })
 
     local hit, entityHit, endCoords, surfaceNormal, materialHash = RayCast(511, 4, rayCastDistance)
+    if not hit then print('missed') lib.hideTextUI() placingSeed = false return end
 
     local ModelHash = Config.WeedProps[1]
     lib.requestModel(ModelHash)


### PR DESCRIPTION
Without checking if hit returns a valid result lib show text will remain on the screen until you use another seed and try again.  This will hide the UI and allow you to return to the top of the event cleaner. rayCastDistance also seems to perform better as 10.0 from testing.